### PR TITLE
Use `gevent.signal_handler` instead of deprecated alias `gevent.signal`

### DIFF
--- a/abci/server.py
+++ b/abci/server.py
@@ -136,9 +136,9 @@ class ABCIServer:
 
         # wait for interrupt
         evt = Event()
-        gevent.signal(signal.SIGQUIT, evt.set)
-        gevent.signal(signal.SIGTERM, evt.set)
-        gevent.signal(signal.SIGINT, evt.set)
+        gevent.signal_handler(signal.SIGQUIT, evt.set)
+        gevent.signal_handler(signal.SIGTERM, evt.set)
+        gevent.signal_handler(signal.SIGINT, evt.set)
         evt.wait()
 
         log.info("Shutting down server")


### PR DESCRIPTION
This resolves #41. See the issue for more details.